### PR TITLE
Add Live log dashboard example and Click plugin

### DIFF
--- a/examples/log_dashboard.py
+++ b/examples/log_dashboard.py
@@ -1,0 +1,67 @@
+"""Simple real-time dashboard combining progress and log output."""
+
+from __future__ import annotations
+
+import random
+import time
+from collections import deque
+from threading import Thread
+
+from rich.console import Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.table import Table
+
+# store recent log messages
+log_messages: deque[tuple[str, str]] = deque(maxlen=10)
+
+
+def worker(name: str, task_total: int, progress: Progress) -> None:
+    task_id = progress.add_task(name, total=task_total)
+    for i in range(task_total):
+        time.sleep(random.uniform(0.1, 0.3))
+        progress.update(task_id, advance=1)
+        if i % 5 == 0:
+            log_messages.append((name, f"step {i}/{task_total}"))
+    log_messages.append((name, "completed"))
+
+
+def make_layout() -> Group:
+    log_table = Table(box=None)
+    log_table.add_column("Task", style="cyan", no_wrap=True)
+    log_table.add_column("Message", style="magenta")
+    for task, message in log_messages:
+        log_table.add_row(task, message)
+    return Group(
+        Panel(progress, title="Progress", border_style="green"),
+        Panel(log_table, title="Logs", border_style="blue"),
+    )
+
+
+progress = Progress(
+    SpinnerColumn(),
+    TextColumn("{task.description}"),
+    BarColumn(),
+    TextColumn("{task.percentage:>3.0f}%"),
+    TimeElapsedColumn(),
+)
+
+threads = [
+    Thread(target=worker, args=(f"job {n}", 40, progress), daemon=True)
+    for n in range(1, 4)
+]
+for thread in threads:
+    thread.start()
+
+with Live(make_layout(), refresh_per_second=10) as live:
+    while any(thread.is_alive() for thread in threads):
+        live.update(make_layout())
+        time.sleep(0.1)
+    live.update(make_layout())

--- a/rich/click_ext.py
+++ b/rich/click_ext.py
@@ -1,0 +1,50 @@
+"""Utilities to integrate Rich with the click framework."""
+
+from __future__ import annotations
+
+from typing import Optional, Any
+
+import click
+from rich.console import Console
+
+
+_DEF_CONSOLE: Console | None = None
+
+
+def install(console: Optional[Console] = None) -> Console:
+    """Patch ``click.echo`` so that it writes with Rich ``Console``.
+
+    Args:
+        console: Optional console instance to use, otherwise a new one is
+            created.
+
+    Returns:
+        The :class:`~rich.console.Console` used for output.
+    """
+    global _DEF_CONSOLE
+    _DEF_CONSOLE = console or Console()
+
+    def _rich_echo(
+        message: Any | None = None,
+        file: Any | None = None,
+        nl: bool = True,
+        err: bool = False,
+        color: Any | None = None,
+    ) -> None:
+        if message is not None:
+            _DEF_CONSOLE.print(message)
+        if nl:
+            _DEF_CONSOLE.print()
+
+    click.echo = _rich_echo  # type: ignore[assignment]
+    return _DEF_CONSOLE
+
+
+class RichGroup(click.Group):
+    """Subclass of ``click.Group`` that renders help with Rich."""
+
+    def get_help(self, ctx: click.Context) -> str:  # pragma: no cover - thin wrapper
+        console = _DEF_CONSOLE or Console()
+        with console.capture() as capture:
+            console.print(super().get_help(ctx))
+        return capture.get()


### PR DESCRIPTION
## Summary
- add `log_dashboard.py` demonstrating Live progress with a log table
- provide `click_ext` plugin with `install` and `RichGroup`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'markdown_it')*

------
https://chatgpt.com/codex/tasks/task_e_684df25ffc308329b50191d37bae859c