### PR TITLE
Improve status context manager test

### DIFF
--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,4 +1,7 @@
 from time import sleep
+from threading import Event, enumerate as enumerate_threads
+
+import rich.live as live
 
 from rich.console import Console
 from rich.spinner import Spinner
@@ -7,7 +10,12 @@ from rich.status import Status
 
 def test_status():
     console = Console(
-        color_system=None, width=80, legacy_windows=False, get_time=lambda: 0.0
+        color_system=None,
+        width=80,
+        legacy_windows=False,
+        get_time=lambda: 0.0,
+        force_terminal=True,
+        _environ={},
     )
     status = Status("foo", console=console)
     assert status.console == console
@@ -19,9 +27,35 @@ def test_status():
     status.update(spinner="dots2")
     assert previous_status_renderable != status.renderable
 
-    # TODO: Testing output is tricky with threads
+    stop_event = Event()
+
+    def patched_run(self) -> None:  # type: ignore[override]
+        with self.live._lock:
+            if not self.done.is_set():
+                self.live.refresh()
+        stop_event.set()
+        self.done.wait()
+
+    original_run = live._RefreshThread.run
+    live._RefreshThread.run = patched_run  # type: ignore[assignment]
+
+    console.begin_capture()
     with status:
-        sleep(0.2)
+        assert stop_event.wait(1)
+    output = console.end_capture()
+
+    live._RefreshThread.run = original_run  # restore
+
+    assert "\u28fe bar" in output  # \u28fe is '⣾'
+    assert status._live._refresh_thread is None
+    assert not status._live.is_started
+    assert console._live is None
+
+    sleep(0.05)
+    assert not any(
+        isinstance(t, live._RefreshThread) and t.is_alive()
+        for t in enumerate_threads()
+    )
 
 
 def test_renderable():


### PR DESCRIPTION
## Summary
- patch `_RefreshThread` in test to stop deterministically
- capture console output while status is active
- assert spinner output and clean termination of threads

## Testing
- `pytest -q tests/test_status.py`

------
https://chatgpt.com/codex/tasks/task_e_684df29a851c83298044c1fbf2fcea6a